### PR TITLE
Added non windows build support

### DIFF
--- a/BlobGame/Application.cs
+++ b/BlobGame/Application.cs
@@ -134,11 +134,22 @@ internal static class Application {
         Game.GameManager.Unload();
     }
 
+#if WINDOWS
     [DllImport("kernel32.dll")]
     static extern IntPtr GetConsoleWindow();
 
     [DllImport("user32.dll")]
     static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+#else
+    // Linux (and macOS probably) don't open a console window by default
+    static IntPtr GetConsoleWindow(){
+        return 0;
+    }
+    static bool ShowWindow(IntPtr hWnd, int nCmdShow){
+        return false;
+    }
+#endif
+
 
     const int SW_HIDE = 0;
     const int SW_SHOW = 5;


### PR DESCRIPTION
Linux and macOS don't have the `kernel32.dll` and `user32.dll` files. However, linux doesn't open a console window anyways, so the functions can just be empty.